### PR TITLE
Support finagle connection pooling

### DIFF
--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -43,8 +43,14 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse]) {
     name <- parse(sql)
   } yield new PreparedStatementImpl(name)
 
-  def close() {
-    factory.close()
+  def close() = {
+    underlying flatMap { service =>
+      resetConnection() flatMap { response => service.close() }
+    }
+  }
+
+  private[this] def resetConnection(): Future[QueryResponse] = {
+    sync() flatMap { _ => query("DISCARD ALL;") }
   }
 
   private[this] def parse(sql: String): Future[String] = {

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Connection.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Connection.scala
@@ -104,6 +104,7 @@ class ConnectionStateMachine(state: State = AuthenticationRequired) extends Stat
     case (CommandComplete(Insert(count)), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(count)))
     case (CommandComplete(Update(count)), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(count)))
     case (CommandComplete(Delete(count)), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(count)))
+    case (CommandComplete(DiscardAll), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(1)))
     case (RowDescription(fields), SimpleQuery) => (None, AggregateRows(fields.map(f => Field(f.name, f.fieldFormat, f.dataType))))
     case (ErrorResponse(details), SimpleQuery) => (None, EmitOnReadyForQuery(Error(details)))
   }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Messages.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Messages.scala
@@ -51,6 +51,8 @@ case object CreateTable extends CommandCompleteStatus
 
 case object DropTable extends CommandCompleteStatus
 
+case object DiscardAll extends CommandCompleteStatus
+
 case class Insert(count : Int) extends CommandCompleteStatus
 
 case class Update(count : Int) extends CommandCompleteStatus
@@ -312,6 +314,8 @@ class BackendMessageParser {
       CreateTable
     } else if (tag == "DROP TABLE") {
       DropTable
+    } else if (tag == "DISCARD ALL") {
+      DiscardAll
     } else {
       val parts = tag.split(" ")
 

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/PgCodec.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/PgCodec.scala
@@ -22,7 +22,7 @@ class PgCodec(user: String, password: Option[String], database: String) extends 
         }
       }
 
-      override def prepareServiceFactory(underlying: ServiceFactory[PgRequest, PgResponse]) = {
+      override def prepareConnFactory(underlying: ServiceFactory[PgRequest, PgResponse]) = {
         val errorHandling = new HandleErrorsProxy(underlying)
         new AuthenticationProxy(errorHandling, user, password, database)
       }


### PR DESCRIPTION
This patch leaves the Client able to be used with a user-provided
ServiceFactory, for configurable hostConnectionLimit, timeouts,
logging, etc.
- Fix Client.close() to close its underlying service rather than the
  service factory (which was a noop).
- Add Client.resetConnection(), which can be used to reset a
  connection back to a state before any statements were prepared.
- Add support for "DISCARD ALL" to Connection and Messages in support
  of resetConnection().
- Move the authentication proxy and errors proxy to prepareConnFactory
  (from prepareServiceFactory) so they're connection-scoped rather
  than factory-scoped.
