### PR TITLE
Fixes an issue with wrong type-parameter passed to getOption

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,7 @@ object FinaglePostgres extends Build {
   lazy val publishSettings = Seq(
     publishMavenStyle := true,
     publishArtifact := true,
-    publishTo := Some(Resolver.file("localDirectory", file("/static/repo"))),
+    publishTo := Some(Resolver.file("localDirectory", file(Path.userHome.absolutePath + "/repo"))),
     licenses := Seq("Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     homepage := Some(url("https://github.com/mairbek/finagle-postgres")),
     pomExtra := (

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,13 +8,13 @@ object FinaglePostgres extends Build {
     libraryDependencies ++= Seq(
       "org.specs2" %% "specs2" % "1.14" % "it,test",
       "junit" % "junit" % "4.7" % "test, it",
-      "com.twitter" %% "finagle-core" % "6.10.0"
+      "com.twitter" %% "finagle-core" % "6.14.0"
     ))
 
   lazy val buildSettings = Seq(
     organization := "com.github.mairbek",
-    version := "6.10.0.2-SNAPSHOT",
-    scalaVersion := "2.10.2"
+    version := "6.14.0.2.9-SNAPSHOT",
+    scalaVersion := "2.10.3"
   )
 
   lazy val publishSettings = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,7 +1,6 @@
 import sbt._
 import Keys._
 
-
 object FinaglePostgres extends Build {
 
   val baseSettings = Defaults.defaultSettings ++ Seq(resolvers += "twitter-repo" at "http://maven.twttr.com",
@@ -13,22 +12,14 @@ object FinaglePostgres extends Build {
 
   lazy val buildSettings = Seq(
     organization := "com.github.mairbek",
-    version := "6.14.0.2.9-SNAPSHOT",
+    version := "6.14.0.2.9",
     scalaVersion := "2.10.3"
   )
 
   lazy val publishSettings = Seq(
     publishMavenStyle := true,
     publishArtifact := true,
-    //publishTo := Some(Resolver.file("localDirectory", file(Path.userHome.absolutePath + "/Projects/personal/mvn-repo"))),
-    credentials += Credentials(Path.userHome / ".thefactory" / "credentials"),
-    publishTo <<= version { (v: String) =>
-      val nexus = "http://maven.thefactory.com/nexus/content/repositories/"
-      if (v.trim.endsWith("SNAPSHOT"))
-        Some("snapshots" at nexus + "snapshots")
-      else
-        Some("releases"  at nexus + "releases")
-    },
+    publishTo := Some(Resolver.file("localDirectory", file(Path.userHome.absolutePath + "/repo"))),
     licenses := Seq("Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     homepage := Some(url("https://github.com/mairbek/finagle-postgres")),
     pomExtra := (
@@ -36,18 +27,18 @@ object FinaglePostgres extends Build {
         <url>git://github.com/mairbek/finagle-postgres.git</url>
         <connection>scm:git://github.com/mairbek/finagle-postgres.git</connection>
       </scm>
-        <developers>
-          <developer>
-            <id>mairbek</id>
-            <name>Mairbek Khadikov</name>
-            <url>http://github.com/mairbek</url>
-          </developer>
-        </developers>)
+      <developers>
+        <developer>
+          <id>mairbek</id>
+          <name>Mairbek Khadikov</name>
+          <url>http://github.com/mairbek</url>
+        </developer>
+      </developers>
+    )
   )
 
   lazy val root = Project(id = "finagle-postgres",
     base = file("."),
     settings = Defaults.itSettings ++ baseSettings ++ buildSettings ++ publishSettings)
       .configs( IntegrationTest)
-
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,7 @@ object FinaglePostgres extends Build {
   lazy val publishSettings = Seq(
     publishMavenStyle := true,
     publishArtifact := true,
-    publishTo := Some(Resolver.file("localDirectory", file(Path.userHome.absolutePath + "/repo"))),
+    publishTo := Some(Resolver.file("localDirectory", file("/static/repo"))),
     licenses := Seq("Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     homepage := Some(url("https://github.com/mairbek/finagle-postgres")),
     pomExtra := (

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,13 +8,12 @@ object FinaglePostgres extends Build {
     libraryDependencies ++= Seq(
       "org.specs2" %% "specs2" % "1.14" % "it,test",
       "junit" % "junit" % "4.7" % "test, it",
-      "com.twitter" %% "finagle-core" % "6.5.0",
-      "com.twitter" %% "util-logging" % "6.3.6"
+      "com.twitter" %% "finagle-core" % "6.8.1"
     ))
 
   lazy val buildSettings = Seq(
     organization := "com.github.mairbek",
-    version := "0.0.4-SNAPSHOT",
+    version := "6.8.1-SNAPSHOT",
     scalaVersion := "2.10.2"
   )
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ object FinaglePostgres extends Build {
 
   lazy val buildSettings = Seq(
     organization := "com.github.mairbek",
-    version := "6.10.0.1-SNAPSHOT",
+    version := "6.10.0.2-SNAPSHOT",
     scalaVersion := "2.10.2"
   )
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -22,7 +22,15 @@ object FinaglePostgres extends Build {
   lazy val publishSettings = Seq(
     publishMavenStyle := true,
     publishArtifact := true,
-    publishTo := Some(Resolver.file("localDirectory", file(Path.userHome.absolutePath + "/Projects/personal/mvn-repo"))),
+    //publishTo := Some(Resolver.file("localDirectory", file(Path.userHome.absolutePath + "/Projects/personal/mvn-repo"))),
+    credentials += Credentials(Path.userHome / ".thefactory" / "credentials"),
+    publishTo <<= version { (v: String) =>
+      val nexus = "http://maven.thefactory.com/nexus/content/repositories/"
+      if (v.trim.endsWith("SNAPSHOT"))
+        Some("snapshots" at nexus + "snapshots")
+      else
+        Some("releases"  at nexus + "releases")
+    },
     licenses := Seq("Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     homepage := Some(url("https://github.com/mairbek/finagle-postgres")),
     pomExtra := (

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ object FinaglePostgres extends Build {
 
   val baseSettings = Defaults.defaultSettings ++ Seq(resolvers += "twitter-repo" at "http://maven.twttr.com",
     libraryDependencies ++= Seq(
-      "org.specs2" %% "specs2" % "1.12.2" % "it,test",
+      "org.specs2" %% "specs2" % "1.14" % "it,test",
       "junit" % "junit" % "4.7" % "test, it",
       "com.twitter" %% "finagle-core" % "6.5.0",
       "com.twitter" %% "util-logging" % "6.3.6"
@@ -15,7 +15,7 @@ object FinaglePostgres extends Build {
   lazy val buildSettings = Seq(
     organization := "com.github.mairbek",
     version := "0.0.3-SNAPSHOT",
-    scalaVersion := "2.9.2"
+    scalaVersion := "2.10.2"
   )
 
   lazy val publishSettings = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ object FinaglePostgres extends Build {
 
   lazy val buildSettings = Seq(
     organization := "com.github.mairbek",
-    version := "6.10.0-SNAPSHOT",
+    version := "6.10.0.1-SNAPSHOT",
     scalaVersion := "2.10.2"
   )
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,12 +8,12 @@ object FinaglePostgres extends Build {
     libraryDependencies ++= Seq(
       "org.specs2" %% "specs2" % "1.14" % "it,test",
       "junit" % "junit" % "4.7" % "test, it",
-      "com.twitter" %% "finagle-core" % "6.8.1"
+      "com.twitter" %% "finagle-core" % "6.10.0"
     ))
 
   lazy val buildSettings = Seq(
     organization := "com.github.mairbek",
-    version := "6.8.1-SNAPSHOT",
+    version := "6.10.0-SNAPSHOT",
     scalaVersion := "2.10.2"
   )
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,7 @@ object FinaglePostgres extends Build {
 
   lazy val buildSettings = Seq(
     organization := "com.github.mairbek",
-    version := "0.0.3-SNAPSHOT",
+    version := "0.0.4-SNAPSHOT",
     scalaVersion := "2.10.2"
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,0 @@
-sbt.version=0.12.3
-#sbt.version=0.11.3

--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -144,7 +144,7 @@ class Row(val fields: IndexedSeq[String], val vals: IndexedSeq[Value[Any]]) {
 
   def get[A](name: String)(implicit mf:Manifest[A]):A = {
     indexMap.get(name).map(vals(_)) match {
-      case Some(Value(x:A)) => x
+      case Some(Value(x)) => x.asInstanceOf[A]
       case _ => throw new IllegalStateException("Expected type " + mf.toString)
     }
   }

--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -161,6 +161,13 @@ class Row(val fields: IndexedSeq[String], val vals: IndexedSeq[Value[Any]]) {
     }
   }
 
+  def getOrElse[A](name: String, default: => A)(implicit mf:Manifest[A]):A = {
+    getOption[A](name) match {
+      case Some(x) => x
+      case _ => default
+    }
+  }
+
   def get(index: Int): Value[Any] = vals(index)
 
   def values(): IndexedSeq[Value[Any]] = vals

--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -1,10 +1,11 @@
 package com.twitter.finagle.postgres
 
 import com.twitter.finagle.ServiceFactory
+import com.twitter.finagle.Service
 import com.twitter.finagle.builder.ClientBuilder
 import protocol._
 import com.twitter.util.Future
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import protocol.Describe
 import protocol.Field
 import protocol.CommandCompleteResponse
@@ -17,11 +18,16 @@ import protocol.Rows
 import protocol.Value
 import org.jboss.netty.buffer.ChannelBuffer
 import scala.util.Random
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.JavaConverters._
+import com.twitter.logging.Logger
+
 
 class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
-  private[this] lazy val underlying = factory.apply()
-  private[this] val counter = new AtomicInteger(0)
+  private[this] val counter = new AtomicLong(0)
   private[this] lazy val customTypes = CustomOIDProxy.serviceOIDMap(id)
+  private[this] val pool = new ConcurrentHashMap[String, Service[PgRequest, PgResponse]]().asScala
+  private[this] val logger = Logger("client")
 
   def query(sql: String): Future[QueryResponse] = sendQuery(sql) {
     case SelectResult(fields, rows) => Future(ResultSet(fields, rows, customTypes))
@@ -36,24 +42,15 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
     case CommandCompleteResponse(rows) => Future(OK(rows))
   }
 
-  def select[T](sql: String)(f: Row => T): Future[Seq[T]] = fetch(sql) map {
-    rs =>
-      extractRows(rs).map(f)
+  def select[T](sql: String)(f: Row => T): Future[Seq[T]] = fetch(sql) map { rs =>
+    extractRows(rs).map(f)
   }
 
   def prepare(sql: String): Future[PreparedStatement] = for {
     name <- parse(sql)
   } yield new PreparedStatementImpl(name)
 
-  def close() = {
-    underlying flatMap { service =>
-      resetConnection() flatMap { response => service.close() }
-    }
-  }
-
-  private[this] def resetConnection(): Future[QueryResponse] = {
-    sync() flatMap { _ => query("DISCARD ALL;") }
-  }
+  def close() = factory.close()
 
   private[this] def parse(sql: String): Future[String] = {
     val name = genName()
@@ -73,14 +70,68 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
 
   private[this] def execute(name: String, maxRows: Int = 0) = fire(PgRequest(Execute(name, maxRows), flush = true))
 
-  private[this] def sync(): Future[Unit] = send(PgRequest(Sync)) {
-    case ReadyForQueryResponse => Future.value(())
-  }
-
   private[this] def sendQuery[T](sql: String)(handler: PartialFunction[PgResponse, Future[T]]) = send(PgRequest(new Query(sql)))(handler)
 
-  private[this] def fire(r: PgRequest) = underlying flatMap {
-    service => service(r)
+  private[this] def close(service: Service[PgRequest, PgResponse]) = for {
+    _ <- service(PgRequest(Sync))
+    _ <- service(PgRequest(new Query("DISCARD ALL;")))
+  } yield service.close()
+
+  private[this] def fire(req: PgRequest) = req.msg match {
+    case Parse(name, _, _) => fireAndRemember(name, req)
+    case Bind(_, name, _, _, _) => fireToRemembered(name, req)
+    case Describe(_, name) => fireToRemembered(name, req)
+    case Execute(name, _) => fireAndRemove(name, req)
+    case _ => fireAndClose(req)
+  }
+
+  private[this] def fireAndRemember(name: String, req: PgRequest) = {
+    logger.ifDebug {
+      s"creating a new service for $name handling the $req"
+    }
+
+    factory() flatMap { service =>
+      service(req) onSuccess { _ =>
+        pool.putIfAbsent(name, service)
+      }
+    }
+  }
+
+  private[this] def fireAndRemove(name: String, req: PgRequest) = {
+    val service = pool(name)
+
+    logger.ifDebug {
+      s"removing service $name handling the $req"
+    }
+
+    service(req) ensure {
+      pool.remove(name, service)
+      close(service)
+    }
+  }
+
+  private[this] def fireToRemembered(name: String, req: PgRequest) = {
+    logger.ifDebug {
+      s"firing to a remembered service $name handling the $req"
+    }
+
+    val service = pool(name)
+    service(req) onFailure { _ =>
+      pool.remove(name, service)
+      close(service)
+    }
+  }
+
+  private[this] def fireAndClose(req: PgRequest) = {
+    logger.ifDebug {
+      "a regular behavior: fire & close handling the $req"
+    }
+
+    factory() flatMap { service =>
+      service(req) ensure {
+        close(service)
+      }
+    }
   }
 
   private[this] def send[T](r: PgRequest)(handler: PartialFunction[PgResponse, Future[T]]) = fire(r) flatMap (handler orElse {
@@ -105,42 +156,33 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
   private[this] class PreparedStatementImpl(name: String) extends PreparedStatement {
     def fire(params: Any*): Future[QueryResponse] = {
       val binaryParams = params.map(p => StringValueEncoder.encode(p))
-      val f = for {
+      for {
         _ <- bind(name, binaryParams)
         (fieldNames, fieldParsers) <- describe(name)
         exec <- execute(name)
       } yield exec match {
-          case CommandCompleteResponse(rows) => OK(rows)
-          case Rows(rows, true) => ResultSet(fieldNames, fieldParsers, rows, customTypes)
-        }
-      f transform {
-        result =>
-          sync().flatMap {
-            _ => Future.const(result)
-          }
+        case CommandCompleteResponse(rows) => OK(rows)
+        case Rows(rows, true) => ResultSet(fieldNames, fieldParsers, rows, customTypes)
       }
     }
   }
 
-
   private[this] def genName() = "fin-pg-" + counter.incrementAndGet
-
 }
 
 object Client {
 
-  def apply(host: String, username: String, password: Option[String], database: String): Client = {
+  def apply(host: String, username: String, password: Option[String], database: String, connectionLimit: Int = 10): Client = {
     val id = Random.alphanumeric.take(28).mkString
 
     val factory: ServiceFactory[PgRequest, PgResponse] = ClientBuilder()
       .codec(new PgCodec(username, password, database, id))
       .hosts(host)
-      .hostConnectionLimit(1)
+      .hostConnectionLimit(connectionLimit)
       .buildFactory()
 
     new Client(factory, id)
   }
-
 }
 
 class Row(val fields: IndexedSeq[String], val vals: IndexedSeq[Value[Any]]) {

--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -148,7 +148,7 @@ class Row(val fields: IndexedSeq[String], val vals: IndexedSeq[Value[Any]]) {
     case _ => None
   }
 
-  def get[A](name: String)(implicit mf: Manifest[A]): A = getOption(name) match {
+  def get[A](name: String)(implicit mf: Manifest[A]): A = getOption[A](name) match {
     case Some(x) => x
     case _ => throw new IllegalStateException("Expected type " + mf.toString)
   }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Connection.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Connection.scala
@@ -145,13 +145,13 @@ class ConnectionStateMachine(state: State = AuthenticationRequired) extends Stat
 
   transition {
     case (NoticeResponse(details), s) =>
-      logger.ifInfo("Notice from server " + details)
+      logger.ifDebug("Notice from server " + details)
       (None, s)
     case (notification: NotificationResponse, s) =>
-      logger.ifInfo("Notification from server " + notification)
+      logger.ifDebug("Notification from server " + notification)
       (None, s)
     case (ParameterStatus(name, value), s) =>
-      logger.ifInfo("Params changed " + name + " " + value)
+      logger.ifDebug("Params changed " + name + " " + value)
       (None, s)
 
   }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Connection.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Connection.scala
@@ -124,6 +124,7 @@ class ConnectionStateMachine(state: State = AuthenticationRequired) extends Stat
     case (CommandComplete(Select(0)), ExecutePreparedStatement) => (Some(Rows(List.empty, completed = true)), Connected)
     case (CommandComplete(Select(_)), AggregateRowsWithoutFields(buff)) => (Some(Rows(buff.toList, completed = true)), Connected)
     case (CommandComplete(Insert(_)), AggregateRowsWithoutFields(buff)) => (Some(Rows(buff.toList, completed = true)), Connected)
+    case (CommandComplete(Update(_)), AggregateRowsWithoutFields(buff)) => (Some(Rows(buff.toList, completed = true)), Connected)
     case (ErrorResponse(details), ExecutePreparedStatement) => (Some(Error(details)), Connected)
     case (ErrorResponse(details), AggregateRowsWithoutFields(_)) => (Some(Error(details)), Connected)
   }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Connection.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Connection.scala
@@ -104,6 +104,7 @@ class ConnectionStateMachine(state: State = AuthenticationRequired) extends Stat
     case (CommandComplete(Insert(count)), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(count)))
     case (CommandComplete(Update(count)), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(count)))
     case (CommandComplete(Delete(count)), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(count)))
+    case (CommandComplete(DiscardAll), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(1)))
     case (RowDescription(fields), SimpleQuery) => (None, AggregateRows(fields.map(f => Field(f.name, f.fieldFormat, f.dataType))))
     case (ErrorResponse(details), SimpleQuery) => (None, EmitOnReadyForQuery(Error(details)))
   }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Messages.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Messages.scala
@@ -51,6 +51,8 @@ case object CreateTable extends CommandCompleteStatus
 
 case object DropTable extends CommandCompleteStatus
 
+case object DiscardAll extends CommandCompleteStatus
+
 case class Insert(count : Int) extends CommandCompleteStatus
 
 case class Update(count : Int) extends CommandCompleteStatus
@@ -312,6 +314,8 @@ class BackendMessageParser {
       CreateTable
     } else if (tag == "DROP TABLE") {
       DropTable
+    } else if (tag == "DISCARD ALL") {
+      DiscardAll
     } else {
       val parts = tag.split(" ")
 

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/PgCodec.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/PgCodec.scala
@@ -50,7 +50,7 @@ class HandleErrorsProxy(delegate: ServiceFactory[PgRequest, PgResponse])
   object HandleErrors extends SimpleFilter[PgRequest, PgResponse] {
     def apply(request: PgRequest, service: Service[PgRequest, PgResponse]) =
       service.apply(request).flatMap {
-        case Error(details) => Future.exception(Errors.server(details.getOrElse("")))
+        case Error(details) => Future.exception(Errors.server("%s\n%s".format(request.toString(), details.getOrElse(""))))
         case r => Future.value(r)
       }
   }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/PgCodec.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/PgCodec.scala
@@ -94,7 +94,7 @@ class AuthenticationProxy(delegate: ServiceFactory[PgRequest, PgResponse], user:
   private[this] def verifyResponse(response: PgResponse): Future[Unit] = {
     response match {
       case AuthenticatedResponse(statuses, processId, secretKey) =>
-        logger.ifInfo("Authenticated " + processId + " " + secretKey + "\n" + statuses)
+        logger.ifDebug("Authenticated " + processId + " " + secretKey + "\n" + statuses)
         Future(Unit)
     }
   }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/PgCodec.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/PgCodec.scala
@@ -25,10 +25,13 @@ class PgCodec(user: String, password: Option[String], database: String, id:Strin
         }
       }
 
-      override def prepareServiceFactory(underlying: ServiceFactory[PgRequest, PgResponse]) = {
+      override def prepareConnFactory(underlying: ServiceFactory[PgRequest, PgResponse]) = {
         val errorHandling = new HandleErrorsProxy(underlying)
-        val authProxy = new AuthenticationProxy(errorHandling, user, password, database)
-        new CustomOIDProxy(authProxy, id)
+        new AuthenticationProxy(errorHandling, user, password, database)
+      }
+
+      override def prepareServiceFactory(underlying: ServiceFactory[PgRequest, PgResponse]) = {
+        new CustomOIDProxy(underlying, id)
       }
     }
   }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
@@ -197,10 +197,10 @@ object StringValueEncoder {
     result
   }
 
-  def convertValue(value:Any):Any = {
+  def convertValue[A](value:A)(implicit mf:Manifest[A]):Any = {
     value match {
-      case m:collection.Map[String, String] => { // this is an hstore, so turn it into one
-        m.map { case (k, v) =>
+      case m:collection.Map[_, _] => { // this is an hstore, so turn it into one
+        m.map { case (k:String, v:String) =>
           """"%s" => "%s"""".format(k, v.replace("\\", "\\\\").replace("\"", "\\\""))
         }.mkString(",")
       }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
@@ -201,7 +201,7 @@ object StringValueEncoder {
     value match {
       case m:collection.Map[_, _] => { // this is an hstore, so turn it into one
         def escape(s:String):String = {
-          s.replace("'", "''")
+          s.replace("'", "''").replace("\\", "\\\\").replace("\"", "\\\"")
         }
         m.map { case (k:String, v:String) =>
           """"%s" => "%s"""".format(escape(k), escape(v))

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
@@ -200,9 +200,12 @@ object StringValueEncoder {
   def convertValue[A](value:A)(implicit mf:Manifest[A]):Any = {
     value match {
       case m:collection.Map[_, _] => { // this is an hstore, so turn it into one
+        def escape(s:String):String = {
+          s.replace("'", "''")
+        }
         m.map { case (k:String, v:String) =>
-          """"%s" => "%s"""".format(k, v.replace("\\", "\\\\").replace("\"", "\\\""))
-        }.mkString(",")
+          """"%s" => "%s"""".format(escape(k), escape(v))
+        }.mkString("'", ",", "'")
       }
       case _ => value
     }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
@@ -201,11 +201,11 @@ object StringValueEncoder {
     value match {
       case m:collection.Map[_, _] => { // this is an hstore, so turn it into one
         def escape(s:String):String = {
-          s.replace("'", "''").replace("\\", "\\\\").replace("\"", "\\\"")
+          s.replace("\\", "\\\\").replace("\"", "\\\"")
         }
         m.map { case (k:String, v:String) =>
           """"%s" => "%s"""".format(escape(k), escape(v))
-        }.mkString("'", ",", "'")
+        }.mkString(",")
       }
       case _ => value
     }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
@@ -192,9 +192,20 @@ object StringValueEncoder {
     if (value == null) {
       result.writeInt(-1)
     } else {
-      result.writeBytes(value.toString.getBytes(Charsets.Utf8))
+      result.writeBytes(convertValue(value).toString.getBytes(Charsets.Utf8))
     }
     result
+  }
+
+  def convertValue(value:Any):Any = {
+    value match {
+      case m:collection.Map[String, String] => { // this is an hstore, so turn it into one
+        m.map { case (k, v) =>
+          """"%s" => "%s"""".format(k, v.replace("\\", "\\\\").replace("\"", "\\\""))
+        }.mkString(",")
+      }
+      case _ => value
+    }
   }
 }
 

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
@@ -167,26 +167,12 @@ object ValueParser {
 
 object StringValueEncoder {
   def encode(value: Any): ChannelBuffer = {
-    value match {
-      case s: String => encodeString(s)
-      case t: Timestamp => encodeTimestamp(t)
-      case _ => encodeError()
-    }
-  }
-
-  private[this] def encodeString(s: String): ChannelBuffer = {
     val result = ChannelBuffers.dynamicBuffer()
-    result.writeBytes(s.getBytes(Charsets.Utf8))
+    if (value == null) {
+      result.writeInt(-1)
+    } else {
+      result.writeBytes(value.toString.getBytes(Charsets.Utf8))
+    }
     result
-  }
-
-  private[this] def encodeTimestamp(t: Timestamp): ChannelBuffer = {
-    encodeString(t.toString())
-  }
-
-  private[this] def encodeError(): ChannelBuffer = {
-    val buf = ChannelBuffers.dynamicBuffer()
-    buf.writeInt(-1)
-    buf
   }
 }

--- a/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/protocol/Values.scala
@@ -4,6 +4,7 @@ import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 import scala.util.parsing.combinator.RegexParsers
 
 import java.sql.Timestamp
+import com.twitter.logging.Logger
 
 object Type {
   val BOOL = 16
@@ -52,9 +53,6 @@ object Type {
   val RECORD = 2249
   val VOID = 2278
   val UUID = 2950
-  val ENUM = 16448
-
-  val HSTORE = 16663
 }
 
 trait ValueParser {
@@ -90,10 +88,9 @@ trait ValueParser {
 
   def parseTimestampTZ(b: ChannelBuffer): Value[Timestamp]
 
-  def parseEnum(b: ChannelBuffer): Value[String]
-
   def parseHStore(b: ChannelBuffer): Value[Map[String, String]]
 
+  def parseUnknown(b: ChannelBuffer): Value[String]
 }
 
 object StringValueParser extends ValueParser {
@@ -127,8 +124,6 @@ object StringValueParser extends ValueParser {
 
   def parseTimestampTZ(b: ChannelBuffer) = parseTimestamp(b)
 
-  def parseEnum(b: ChannelBuffer) = parseStr(b)
-
   def parseHStore(b: ChannelBuffer) = {
     val data = b.toString(Charsets.Utf8)
 
@@ -138,6 +133,8 @@ object StringValueParser extends ValueParser {
     }
   }
 
+  def parseUnknown(b: ChannelBuffer) = parseStr(b)
+
   private[this] def parseInt(b: ChannelBuffer) = Value[Int](b.toString(Charsets.Utf8).toInt)
 
   private[this] def parseStr(b: ChannelBuffer) = Value[String](b.toString(Charsets.Utf8))
@@ -146,7 +143,9 @@ object StringValueParser extends ValueParser {
 
 object ValueParser {
 
-  def parserOf(format: Int, dataType: Int): ChannelBuffer => Value[Any] = {
+  private[this] val logger = Logger("value parser")
+
+  def parserOf(format: Int, dataType: Int, customTypes:Map[String, String]): ChannelBuffer => Value[Any] = {
     val valueParser: ValueParser = format match {
       case 0 => StringValueParser
       case _ => throw new UnsupportedOperationException("TODO Add support for binary format")
@@ -170,7 +169,17 @@ object ValueParser {
         case VAR_CHAR => valueParser.parseVarChar
         case TIMESTAMP => valueParser.parseTimestamp
         case TIMESTAMP_TZ => valueParser.parseTimestampTZ
-        case _ => throw Errors.client("Data type '" + dataType + "' is not supported")
+        case _ => {
+          customTypes.get(dataType.toString) match {
+            case Some("hstore") => {
+              valueParser.parseHStore
+            }
+            case _ => {
+              logger.ifDebug("Unknown data type " + dataType + ", parsing as a unknown")
+              valueParser.parseUnknown
+            }
+          }
+        }
       }
     r
 
@@ -187,7 +196,6 @@ object StringValueEncoder {
     }
     result
   }
-<<<<<<< HEAD
 }
 
 object HStoreStringParser extends RegexParsers {
@@ -201,7 +209,3 @@ object HStoreStringParser extends RegexParsers {
     case failure:NoSuccess => None
   }
 }
-
-=======
-}
->>>>>>> origin/timestamp-enum-support


### PR DESCRIPTION
The current implementation always fails with:

```
java.lang.ClassCastException: java.lang.String cannot be cast to scala.runtime.Nothing$
    at com.twitter.finagle.postgres.Row.get(Client.scala:152)
```

Somebody has forgotten to pass the type-parameter to the `getOption` function. The compiler used `Nothing` as default type. 
